### PR TITLE
use device class API properly, and clarify license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,29 @@
 ### sbig-parport
 
-This is a port of the SBIG parallel port camera driver for Linux from
-an older 2.4 kernel to a modern 4.9 kernel.
+This is a Linux device driver for the older SBIG parallel port
+astronomy cameras such as ST-237, ST-7, ST-8, ST-9.
 
-It is slightly different than the old one, in that it uses the "parport"
-stack and thus doesn't directly access legacy x86 ports.  That allows it
-to work with non-x86 parport hardware, such as
+This version includes changes to support modern kernels, and non-PC
+parallel port devices such as
 [pi-parport](https://github.com/garlick/pi-parport).
 
-### SBIG Universal Driver
+The driver maintains the ABI expected by the SBIG Universal Driver SDK.
+Versions up to 4.84 have been tested.  Parallel port cameras appear to
+the SDK and applications as `LPT1`, `LPT2`, etc..
 
-This driver provides a low-level interface, primarily `ioctl()` based, to the
-SBIG Universal Driver, which provides the documented API for applications.
-Fortunately, support for this interface has not been removed in modern
-versions of the universal driver, at least up to version 4.84
-(`LinuxDevKit-2014-10-27T12-58`).
+### Support
 
-### building
+Issues and pull requests are welcome.
+See also: [project wiki](https://github.com/garlick/sbig-parport/wiki)
 
-You'll need kernel headers or a kernel source tree.  To build against
-headers packaged for your running kernel, run
-```
-$ cd driver
-$ make
-```
-To build against another kernel, set `KERNEL_PATH` or `KERNEL_VERSION`
-on the make command line.
+Note: this driver is no longer supported by SBIG/DL.
 
-### installing
+### Origin and License
 
-```
-$ cd ../udev
-$ sudo cp 51-sbig-parport.rules /etc/udev/rules.d/
-$ sudo udevadm control --reload-rules
-$ sudo udevadm trigger
-```
+This driver was made available for download on the SBIG web site for many
+years, but no explicit license was granted by the copyright holders.
 
-### running
+The bulk of the code appears to have originally been ported from the Windows
+environment.
 
-```
-$ modprobe parport parport_pc
-$ insmod sbiglpt.ko
-```
-
-### testing
-
-I have some old cameras I have tested with.  These include:
-* ST-5C
-* ST-7E
-* ST-9E
-
-I primarily test with [sbig-util](https://github.com/garlick/sbig-util).
-
-Testing is pretty ad-hoc at this point.
-
-### license
-
-This kernel module is proprietary, although its source code was publicly
-distributed by SBIG on its web site for many years.  It cannot be
-re-distributed with the Linux kernel as this would violate the terms of
-the kernel's GPL license.
+SPDX-License-Identifier: UNLICENSED

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -1,6 +1,8 @@
 KERNEL_VERSION ?= $(shell uname -r)
 KERNEL_PATH ?= /lib/modules/$(KERNEL_VERSION)/build
 
+#EXTRA_CFLAGS = -DHAVE_DEVICE_CLASS -DSBIGLPT_LICENSE=\"GPL\"
+
 obj-m += sbiglpt.o
 
 sbiglpt-y = \

--- a/driver/ksbiglptmain.c
+++ b/driver/ksbiglptmain.c
@@ -142,7 +142,7 @@ static int sbig_init_module(void)
 		pr_err("sbiglpt: alloc_chrdev_region failed\n");
 		goto out;
 	}
-	sbig_class = class_create(THIS_MODULE, "chardrv");
+	sbig_class = class_create(THIS_MODULE, "sbiglpt");
 	if (!sbig_class) {
 		pr_err("sbiglpt: class_create failed\n");
 		goto out_reg;

--- a/driver/ksbiglptmain.c
+++ b/driver/ksbiglptmain.c
@@ -20,7 +20,8 @@
 
 #define SBIG_NO 3
 static struct {
-	struct pardevice *dev;
+	struct pardevice *pardev;
+	struct device *dev;
 	spinlock_t spinlock;
 } sbig_table[SBIG_NO];
 static unsigned int sbig_count;
@@ -57,7 +58,8 @@ static int sbig_open(struct inode *inode, struct file *file)
 		goto out_unlock;
 	}
 	pd->buffer_size = LDEFAULT_BUFFER_SIZE;
-	pd->port = sbig_table[minor].dev->port;
+	pd->port = sbig_table[minor].pardev->port;
+	pd->dev = sbig_table[minor].dev;
 	file->private_data = pd;
 out_unlock:
 	spin_unlock(&sbig_table[minor].spinlock);
@@ -91,36 +93,44 @@ static void sbig_attach(struct parport *port)
 	int nr = 0 + sbig_count;
 
 	if (!(port->modes & PARPORT_MODE_PCSPP)) {
-		dev_info(port->dev, "ignoring %s - no SPP capability\n",
-			 port->name);
+		pr_info("%s: ignoring %s - no SPP capability\n",
+			__func__, port->name);
 		return;
 	}
 	if (nr == SBIG_NO) {
-		dev_info(port->dev, "ignoring %s - max %d reached\n",
-			 port->name, SBIG_NO);
+		pr_info("%s: ignoring %s - max %d reached\n",
+			__func__, port->name, SBIG_NO);
 		return;
 	}
-	sbig_table[nr].dev = parport_register_device(port, "sbiglpt", NULL,
-						     NULL, NULL, 0, NULL);
-	if (sbig_table[nr].dev == NULL) {
-		dev_err(port->dev, "parport_register_device failed\n");
+	sbig_table[nr].pardev = parport_register_device(port, "sbiglpt", NULL,
+							NULL, NULL, 0, NULL);
+	if (sbig_table[nr].pardev == NULL) {
+		pr_err("%s: parport_register_device failed\n", __func__);
 		return;
 	}
-	if (parport_claim(sbig_table[nr].dev)) {
-		parport_unregister_device(sbig_table[nr].dev);
-		dev_err(port->dev, "parport_claim failed\n");
-		return;
+	if (parport_claim(sbig_table[nr].pardev)) {
+		pr_err("%s: parport_claim failed\n", __func__);
+		goto out;
 	}
-	device_create(sbig_class, port->dev, MKDEV(MAJOR(sbig_dev), nr), NULL,
-		      "sbiglpt%d", nr);
+	sbig_table[nr].dev = device_create(sbig_class, port->dev,
+					   MKDEV(MAJOR(sbig_dev), nr), NULL,
+					   "sbiglpt%d", nr);
+	if (IS_ERR(sbig_table[nr].dev)) {
+		pr_err("%s: device_create failed\n", __func__);
+		goto out_release;
+	}
 	spin_lock_init(&sbig_table[nr].spinlock);
 	sbig_count++;
-	dev_info(port->dev, "%s claimed by sbiglpt%d\n", port->name, nr);
+	dev_info(sbig_table[nr].dev, "attached to %s\n", port->name);
+	return;
+out_release:
+	parport_release(sbig_table[nr].pardev);
+out:
+	parport_unregister_device(sbig_table[nr].pardev);
 }
 
 static void sbig_detach(struct parport *port)
 {
-	//dev_info(port->dev, "detach %s\n", port->name);
 }
 
 static struct parport_driver sbig_driver = {
@@ -139,21 +149,21 @@ static const struct file_operations sbig_fops = {
 static int sbig_init_module(void)
 {
 	if (alloc_chrdev_region(&sbig_dev, 0, SBIG_NO, "sbiglpt") < 0) {
-		pr_err("sbiglpt: alloc_chrdev_region failed\n");
+		pr_err("%s: alloc_chrdev_region failed\n", __func__);
 		goto out;
 	}
 	sbig_class = class_create(THIS_MODULE, "sbiglpt");
 	if (!sbig_class) {
-		pr_err("sbiglpt: class_create failed\n");
+		pr_err("%s: class_create failed\n", __func__);
 		goto out_reg;
 	}
 	cdev_init(&sbig_cdev, &sbig_fops);
 	if (cdev_add(&sbig_cdev, sbig_dev, SBIG_NO) < 0) {
-		pr_err("sbiglpt: cdev_add failed\n");
+		pr_err("%s: cdev_add failed\n", __func__);
 		goto out_class;
 	}
 	if (parport_register_driver(&sbig_driver)) {
-		pr_err("sbiglpt: parport_register_driver failed\n");
+		pr_err("%s: parport_register_driver failed\n", __func__);
 		goto out_cdev;
 	}
 	return (0);
@@ -174,8 +184,8 @@ static void sbig_cleanup_module(void)
 	parport_unregister_driver(&sbig_driver);
 	cdev_del(&sbig_cdev);
 	for (nr = 0; nr < sbig_count; nr++) {
-		parport_release(sbig_table[nr].dev);
-		parport_unregister_device(sbig_table[nr].dev);
+		parport_release(sbig_table[nr].pardev);
+		parport_unregister_device(sbig_table[nr].pardev);
 		device_destroy(sbig_class, MKDEV(MAJOR(sbig_dev), nr));
 	}
 	class_destroy(sbig_class);

--- a/driver/ksbiglptmain.h
+++ b/driver/ksbiglptmain.h
@@ -18,6 +18,7 @@ struct sbig_client {
 	unsigned char noBytesWr;
 	unsigned short buffer_size;
 	char *buffer;
+	struct device *dev;
 	struct parport *port;
 };
 
@@ -32,13 +33,13 @@ static inline u8 sbig_inb(struct sbig_client *pd)
 }
 
 #define sbig_dbg(pd, fmt, arg...) \
-	dev_dbg((pd)->port->dev, fmt, ##arg)
+	dev_dbg((pd)->dev, fmt, ##arg)
 
 #define sbig_info(pd, fmt, arg...) \
-	dev_info((pd)->port->dev, fmt, ##arg)
+	dev_info((pd)->dev, fmt, ##arg)
 
 #define sbig_err(pd, fmt, arg...) \
-	dev_err((pd)->port->dev, fmt, ##arg)
+	dev_err((pd)->dev, fmt, ##arg)
 
 long sbig_ioctl(struct sbig_client *pd, unsigned int cmd, unsigned long arg,
 		spinlock_t *spin_lock);

--- a/driver/ksbiglptmain.h
+++ b/driver/ksbiglptmain.h
@@ -32,14 +32,26 @@ static inline u8 sbig_inb(struct sbig_client *pd)
 	return pd->port->ops->read_status(pd->port);
 }
 
-#define sbig_dbg(pd, fmt, arg...) \
-	dev_dbg((pd)->dev, fmt, ##arg)
+#define sbig_dbg(pd, fmt, arg...) do { \
+	if ((pd) && (pd)->dev) \
+		dev_dbg((pd)->dev, fmt, ##arg); \
+	else \
+		pr_debug("sbiglpt: " fmt, ##arg); \
+} while (0)
 
-#define sbig_info(pd, fmt, arg...) \
-	dev_info((pd)->dev, fmt, ##arg)
+#define sbig_info(pd, fmt, arg...) do { \
+	if ((pd) && (pd)->dev) \
+		dev_info((pd)->dev, fmt, ##arg); \
+	else \
+		pr_info("sbiglpt: " fmt, ##arg); \
+} while (0)
 
-#define sbig_err(pd, fmt, arg...) \
-	dev_err((pd)->dev, fmt, ##arg)
+#define sbig_err(pd, fmt, arg...) do { \
+	if ((pd) && (pd)->dev) \
+		dev_err((pd)->dev, fmt, ##arg); \
+	else \
+		pr_err("sbiglpt: " fmt, ##arg); \
+} while (0)
 
 long sbig_ioctl(struct sbig_client *pd, unsigned int cmd, unsigned long arg,
 		spinlock_t *spin_lock);


### PR DESCRIPTION
Fix up printk messages that were prefixed with the parallel port info, not the info for this driver.

Stop declaring the module license to be GPL and make the device class (GPL-only) usage conditionally compiled (default off).