### PR TITLE
ensure IOCTL_GET_LAST_ERROR returns valid results

### DIFF
--- a/driver/ioctl.c
+++ b/driver/ioctl.c
@@ -1543,7 +1543,9 @@ long sbig_ioctl(struct sbig_client *pd, unsigned int cmd, unsigned long arg,
 		return -ENOTTY;
 	}
 
-	if (status != CE_NO_ERROR)
+	if (status < 0)
+		gLastError = CE_BAD_PARAMETER;
+	else if (status != CE_NO_ERROR)
 		gLastError = status;
 out:
 	return status;

--- a/driver/ioctl.c
+++ b/driver/ioctl.c
@@ -472,7 +472,7 @@ int KLptWaitForPLD(struct sbig_client *pd)
 		if (!(KLptCameraIn(pd, AD0) & CIP))
 			break;
 		if (t0++ >= CONVERSION_DELAY)
-			return (gLastError = CE_AD_TIMEOUT);
+			return CE_AD_TIMEOUT;
 	}
 	return CE_NO_ERROR;
 }
@@ -489,7 +489,7 @@ int KLptWaitForAD(struct sbig_client *pd)
 		if (!(sbig_inb(pd) & 0x80))
 			break;
 		if (t0++ >= CONVERSION_DELAY)
-			return (gLastError = CE_AD_TIMEOUT);
+			return CE_AD_TIMEOUT;
 	}
 	return CE_NO_ERROR;
 }
@@ -509,7 +509,7 @@ int KLptHClear(struct sbig_client *pd, short times)
 		// wait for PLD
 		status = KLptWaitForPLD(pd);
 		if (status != CE_NO_ERROR)
-			return (gLastError = status);
+			return status;
 	}
 	return CE_NO_ERROR;
 }

--- a/driver/ioctl.c
+++ b/driver/ioctl.c
@@ -1378,34 +1378,42 @@ int KLptTestCommand(struct sbig_client *pd)
 // KLptGetJiffies
 // Get jiffies, ie. number of ticks from the boot time.
 //========================================================================
-int KLptGetJiffies(unsigned long arg)
+int KLptGetJiffies(struct sbig_client *pd, unsigned long arg)
 {
 	int status = put_user((unsigned long)jiffies,
 			      (unsigned long __user *)arg);
-	return status;
+	if (status != 0) {
+		sbig_err(pd, "%s: put_user: error\n", __func__);
+		return -EFAULT;
+	}
+	return CE_NO_ERROR;
 }
 //========================================================================
 // KLptGetHz
 // Get HZ.
 //========================================================================
-int KLptGetHz(unsigned long arg)
+int KLptGetHz(struct sbig_client *pd, unsigned long arg)
 {
 	int status = put_user((unsigned long)HZ,
 			      (unsigned long __user *)arg);
-	return status;
+	if (status != 0) {
+		sbig_err(pd, "%s: put_user: error\n", __func__);
+		return -EFAULT;
+	}
+	return CE_NO_ERROR;
 }
 //========================================================================
 // KSbigLptGetLastError
 //========================================================================
-int KSbigLptGetLastError(unsigned long arg)
+int KSbigLptGetLastError(struct sbig_client *pd, unsigned long arg)
 {
 	int status = put_user(gLastError,
 			      (unsigned short __user *)arg);
-	if (status == 0)
-		gLastError = CE_NO_ERROR;
-	else
-		gLastError = CE_BAD_PARAMETER;
-	return status;
+	if (status != 0) {
+		sbig_err(pd, "%s: put_user: error\n", __func__);
+		return -EFAULT;
+	}
+	return CE_NO_ERROR;
 }
 //========================================================================
 // sbig_ioctl - entry point
@@ -1460,15 +1468,15 @@ long sbig_ioctl(struct sbig_client *pd, unsigned int cmd, unsigned long arg,
 		break;
 
 	case IOCTL_GET_JIFFIES:
-		status = KLptGetJiffies(arg);
+		status = KLptGetJiffies(pd, arg);
 		break;
 
 	case IOCTL_GET_HZ:
-		status = KLptGetHz(arg);
+		status = KLptGetHz(pd, arg);
 		break;
 
 	case IOCTL_GET_LAST_ERROR:
-		status = KSbigLptGetLastError(arg);
+		status = KSbigLptGetLastError(pd, arg);
 		break;
 
 	case IOCTL_DUMP_ILINES:

--- a/driver/ioctl.c
+++ b/driver/ioctl.c
@@ -1523,10 +1523,14 @@ long sbig_ioctl(struct sbig_client *pd, unsigned int cmd, unsigned long arg,
 
 	case IOCTL_SET_BUFFER_SIZE:
 		status = KLptSetBufferSize(pd, spin_lock, arg);
+		if (status > 0)
+			goto out;
 		break;
 
 	case IOCTL_GET_BUFFER_SIZE:
 		status = KLptGetBufferSize(pd);
+		if (status > 0)
+			goto out;
 		break;
 
 	case IOCTL_TEST_COMMAND:
@@ -1541,7 +1545,7 @@ long sbig_ioctl(struct sbig_client *pd, unsigned int cmd, unsigned long arg,
 
 	if (status != CE_NO_ERROR)
 		gLastError = status;
-
+out:
 	return status;
 }
 //========================================================================

--- a/driver/ioctl.c
+++ b/driver/ioctl.c
@@ -1345,7 +1345,7 @@ int KLptSetBufferSize(struct sbig_client *pd, spinlock_t *lock,
 	// allocate new kernel-space I/O buffer
 	kbuff = kmalloc(buffer_size, GFP_KERNEL);
 	if (kbuff == NULL)
-		return pd->buffer_size;
+		goto out;
 
 	// set pointer to new I/O buffer and swap buffers
 	pd->buffer_size = buffer_size;
@@ -1355,18 +1355,15 @@ int KLptSetBufferSize(struct sbig_client *pd, spinlock_t *lock,
 	kfree(pd->buffer);
 	pd->buffer = kbuff;
 	spin_unlock(lock);
-
-	status = pd->buffer_size;
-	sbig_dbg(pd, "%s: %d\n", __func__, status);
-	return status;
+out:
+	sbig_dbg(pd, "%s: %u\n", __func__, pd->buffer_size);
+	return pd->buffer_size;
 }
 //========================================================================
 int KLptGetBufferSize(struct sbig_client *pd)
 {
-	enum par_error status = pd->buffer_size;
-
-	sbig_dbg(pd, "%s: %d\n", __func__, status);
-	return status;
+	sbig_dbg(pd, "%s: %u\n", __func__, pd->buffer_size);
+	return pd->buffer_size;
 }
 //========================================================================
 int KLptTestCommand(struct sbig_client *pd)

--- a/driver/sbiglpt_module.h
+++ b/driver/sbiglpt_module.h
@@ -13,6 +13,7 @@ struct sbig_client {
 	unsigned char imaging_clocks_out;
 	unsigned char noBytesRd;
 	unsigned char noBytesWr;
+	unsigned short last_error;
 	unsigned short buffer_size;
 	char *buffer;
 	struct device *dev;


### PR DESCRIPTION
Rework some of the ioctl error handling so that the IOCTL_GET_LAST_ERROR request always returns a valid CE_* error.

Fixes #10