### PR TITLE
travis-ci: build in multiple environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ addons:
     sources:
     packages:
       - libelf-dev
-      - linux-headers-3.13.0-100-generic
+      - linux-headers-4.4.0-184-generic
 
 script:
  - make -C driver check
- - KERNEL_VERSION=3.13.0-100-generic make -C driver
+ - KERNEL_VERSION=4.4.0-184-generic make -C driver

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     packages:
       - libelf-dev
       - linux-headers-3.13.0-100-generic
-      - libgtk2.0-dev
 
 script:
  - make -C driver check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,41 @@
 language: c
 
-sudo: false
-
 compiler:
   - gcc
 
-addons:
-  apt:
-    sources:
-    packages:
-      - libelf-dev
-      - linux-headers-4.4.0-184-generic
-
-script:
- - make -C driver check
- - KERNEL_VERSION=4.4.0-184-generic make -C driver
+jobs:
+  include:
+  - name: 'Run linux kernel checkpatch.pl script'
+    script: make -C driver check
+  - name: 'Build kernel module with linux-4.4.0 headers'
+    arch: amd64
+    dist: xenial
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.4.0-184-generic
+    script:
+    - KERNEL_VERSION=4.4.0-184-generic make -C driver
+  - name: 'Build kernel module with linux-4.4.0 headers'
+    arch: arm64
+    dist: xenial
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.4.0-184-generic
+    script:
+    - KERNEL_VERSION=4.4.0-184-generic make -C driver
+  - name: 'Build kernel module with linux-4.15.0 headers'
+    arch: amd64
+    dist: bionic
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.15.0-106-generic
+    script:
+    - KERNEL_VERSION=4.15.0-106-generic make -C driver
+  - name: 'Build kernel module with linux-4.15.0 headers'
+    arch: arm64
+    dist: bionic
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.15.0-106-generic
+    script:
+    - KERNEL_VERSION=4.15.0-106-generic make -C driver


### PR DESCRIPTION
As described in #15, the kernel version (3.13) we were using vanished from the xenial apt repo.

Update to the current xenial kernel version (4.4), and add a build matrix to build each pull request against linux-4.4 (xenial) and linux-4.15 (bionic) on amd64 and arm64 architectures.